### PR TITLE
Deploy/Destroy command fix

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -5,9 +5,6 @@ import { DatabaseStack } from "../lib/database-stack";
 import { SecurityStack } from "../lib/security-stack";
 import { ApplicationStack } from "../lib/application-stack";
 import { UserFrontendStack } from "../lib/frontend-stack";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 const app = new cdk.App();
 
@@ -28,7 +25,7 @@ const projectName = process.env.PROJECT_NAME || generateRandomVPCPrefix();
 
 const environment = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.DEFAULT_REGION || "us-east-1",
+  region: process.env.CDK_DEFAULT_REGION || "us-east-1",
 };
 
 const networkStack = new NetworkStack(app, "Pendulum-NetworkStack", {
@@ -57,8 +54,8 @@ const applicationStack = new ApplicationStack(
     databaseEndpoint: databaseStack.clusterEndpoint,
     databaseSecret: databaseStack.secret,
     containerEnvironment: {
-      DB_NAME: process.env.DB_NAME || "test",
-      PORT: process.env.PORT || "3000",
+      DB_NAME: "pendulum",
+      PORT: "3000",
     },
     jwtSecret: securityStack.jwtSecret,
     adminApiKey: securityStack.adminApiKey,

--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -4,7 +4,6 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as secretsManager from "aws-cdk-lib/aws-secretsmanager";
-import { PrivateDnsNamespace } from "aws-cdk-lib/aws-servicediscovery";
 import { Construct } from "constructs";
 
 interface ApplicationStackProps extends cdk.StackProps {

--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -13,9 +13,6 @@ interface ApplicationStackProps extends cdk.StackProps {
   databaseEndpoint: string;
   databaseSecret: secretsManager.Secret;
   containerEnvironment: Record<string, string>;
-  containerRegistryURI: string;
-  appImageTag: string;
-  eventsImageTag: string;
   jwtSecret: secretsManager.Secret;
   adminApiKey: secretsManager.Secret;
 }
@@ -83,7 +80,7 @@ export class ApplicationStack extends cdk.Stack {
     // add app container
     const appContainer = appTaskDef.addContainer("AppContainer", {
       image: ecs.ContainerImage.fromRegistry(
-        `${props.containerRegistryURI}:${props.appImageTag}`,
+        "public.ecr.aws/f6o9b2p8/pendulum/core:app-latest",
       ),
       environment: {
         ...props.containerEnvironment,
@@ -92,7 +89,7 @@ export class ApplicationStack extends cdk.Stack {
         EVENTS_SERVICE_URL: "http://events:8080",
         PORT: "3000",
         NODE_ENV: "production",
-        DB_NAME: "pendulum-test",
+        DB_NAME: "pendulum",
       },
       secrets: {
         DB_USER: ecs.Secret.fromSecretsManager(
@@ -141,7 +138,7 @@ export class ApplicationStack extends cdk.Stack {
     // add events container
     const eventsContainer = eventsTaskDef.addContainer("EventsContainer", {
       image: ecs.ContainerImage.fromRegistry(
-        `${props.containerRegistryURI}:${props.eventsImageTag}`,
+        "public.ecr.aws/f6o9b2p8/pendulum/core:events-latest"
       ),
       environment: {
         ...props.containerEnvironment,

--- a/lib/database-stack.ts
+++ b/lib/database-stack.ts
@@ -1,11 +1,8 @@
-import dotenv from "dotenv";
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as secretsManager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { DatabaseCluster } from "aws-cdk-lib/aws-docdb";
-
-dotenv.config();
 
 interface DatabaseStackProps extends cdk.StackProps {
   vpc: ec2.Vpc;
@@ -24,7 +21,7 @@ export class DatabaseStack extends cdk.Stack {
       description: "Pendulum DocumentDB cluster credentials",
       generateSecretString: {
         secretStringTemplate: JSON.stringify({
-          username: process.env.DB_USER || "mongouser"
+          username: "admin",
         }),
         generateStringKey: "password",
         excludeCharacters: '"@/\\:?#[]%&=+',

--- a/lib/database-stack.ts
+++ b/lib/database-stack.ts
@@ -21,7 +21,7 @@ export class DatabaseStack extends cdk.Stack {
       description: "Pendulum DocumentDB cluster credentials",
       generateSecretString: {
         secretStringTemplate: JSON.stringify({
-          username: "admin",
+          username: "pendulumuser",
         }),
         generateStringKey: "password",
         excludeCharacters: '"@/\\:?#[]%&=+',

--- a/lib/network-stack.ts
+++ b/lib/network-stack.ts
@@ -3,10 +3,14 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Vpc } from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 
+interface NetworkStackProps extends cdk.StackProps {
+  projectName: string;
+}
+
 export class NetworkStack extends cdk.Stack {
   public readonly vpc: Vpc;
 
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: NetworkStackProps) {
     super(scope, id, props);
 
     /*
@@ -20,7 +24,7 @@ export class NetworkStack extends cdk.Stack {
 				- private 'db' subnet for DocumentDBs with no egress allowed
 			- 1 NAT Gateway automatically placed in one of the public subnets
 	 */
-    this.vpc = new Vpc(this, "VPC", {
+    this.vpc = new Vpc(this, `${props.projectName}-VPC`, {
       subnetConfiguration: [
         {
           cidrMask: 24,

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -19,6 +19,8 @@ async function listAllStacks() {
       "Pendulum-NetworkStack",
     ];
 
+    spinner.succeed("Pendulum stacks identified.");
+
     return potentialStacks;
   } catch (error: any) {
     spinner.fail("Failed to connect to AWS");
@@ -33,7 +35,7 @@ async function destroyStacks(
 ) {
   console.log(chalk.blue("\nDestroy Info:"));
   console.log(chalk.gray(`  Account: ${accountId}`));
-  console.log(chalk.gray(`  Region: ${region}`));
+  console.log(chalk.gray(`  Region: ${region}\n`));
 
   for (const stack of stacks) {
     try {
@@ -77,9 +79,11 @@ async function destroyStacks(
       );
 
       console.log(chalk.green(`Successfully destroyed: ${stack}`));
+      console.log("");
     } catch (error: any) {
       console.log(chalk.yellow(`Couldn't destroy ${stack}: ${error.message}`));
       console.log(chalk.gray("This might be normal if stack doesn't exist"));
+      console.log("");
     }
   }
 }

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
 import inquirer from "inquirer";
 import ora from "ora";
-import { resolve } from "path";
 import { runCommand } from "../utils/runCommand";
 import { checkAWSConfiguration } from "../utils/checkAWSConfiguration";
 import { getAWSConfiguration } from "../utils/getAWSConfiguration";
@@ -14,13 +13,12 @@ async function listAllStacks() {
 
     const potentialStacks = [
       "Pendulum-FrontendStack",
-      "Pendulum-ApplicationStack", 
+      "Pendulum-ApplicationStack",
       "Pendulum-DatabaseStack",
       "Pendulum-SecurityStack",
-      "Pendulum-NetworkStack"
+      "Pendulum-NetworkStack",
     ];
 
-    spinner.succeed("Ready to destroy Pendulum stacks");
     return potentialStacks;
   } catch (error: any) {
     spinner.fail("Failed to connect to AWS");
@@ -29,29 +27,54 @@ async function listAllStacks() {
 }
 
 async function destroyStacks(
-  cliPath: string,
   accountId: string,
   region: string,
-  stacks: string[]
+  stacks: string[],
 ) {
   console.log(chalk.blue("\nDestroy Info:"));
-  console.log(chalk.gray(`  CLI Path: ${cliPath}`));
   console.log(chalk.gray(`  Account: ${accountId}`));
   console.log(chalk.gray(`  Region: ${region}`));
 
-  for (const stack of stacks.reverse()) {
-    console.log(chalk.blue(`\nAttempting to destroy: ${stack}`));
-
+  for (const stack of stacks) {
     try {
-      await runCommand("npx", ["cdk", "destroy", stack, "--force"], {
-        cwd: cliPath,
-        env: {
-          ...process.env,
-          CDK_DEFAULT_ACCOUNT: accountId,
-          CDK_DEFAULT_REGION: region,
+      await runCommand(
+        "aws",
+        [
+          "cloudformation",
+          "delete-stack",
+          "--stack-name",
+          stack,
+          "--region",
+          region,
+        ],
+        {
+          env: {
+            ...process.env,
+          },
+          stdio: "pipe",
         },
-        stdio: "pipe",
-      });
+      );
+
+      console.log(chalk.yellow(`Initiated deletion of: ${stack}`));
+
+      await runCommand(
+        "aws",
+        [
+          "cloudformation",
+          "wait",
+          "stack-delete-complete",
+          "--stack-name",
+          stack,
+          "--region",
+          region,
+        ],
+        {
+          env: {
+            ...process.env,
+          },
+          stdio: "pipe",
+        },
+      );
 
       console.log(chalk.green(`Successfully destroyed: ${stack}`));
     } catch (error: any) {
@@ -73,15 +96,13 @@ async function destroyStacks(
 export async function DestroyCommand() {
   console.log(chalk.red("Destroying from AWS..."));
 
-  const cliPath = resolve(__dirname, "../..");
-  console.log(chalk.gray(`Using CLI from: ${cliPath}`));
-
   try {
-    const fs = await import("fs/promises");
-    await fs.access(resolve(cliPath, "package.json"));
-    console.log(chalk.green("CLI files found"));
+    await runCommand("aws", ["--version"], { stdio: "pipe" });
   } catch (error) {
-    console.log(chalk.red("Pendulum project not found!"));
+    console.log(chalk.red("AWS CLI not found!"));
+    console.log(
+      chalk.yellow("Please install AWS CLI: https://aws.amazon.com/cli/"),
+    );
     return;
   }
 
@@ -89,7 +110,8 @@ export async function DestroyCommand() {
     {
       type: "confirm",
       name: "proceed",
-      message: "This will permanently destroy your Pendulum deployment from " +
+      message:
+        "This will permanently destroy your Pendulum deployment from " +
         "AWS. Continue?",
       default: false,
     },
@@ -103,9 +125,11 @@ export async function DestroyCommand() {
   const { awsAccountId, awsRegion } = await getAWSConfiguration();
 
   console.log(chalk.yellow("\nWARNING: This action is irreversible!"));
-  console.log(chalk.yellow(
-    "All data in your Pendulum deployment will be permanently lost."
-  ));
+  console.log(
+    chalk.yellow(
+      "All data in your Pendulum deployment will be permanently lost.",
+    ),
+  );
   console.log(chalk.yellow("This includes:"));
   console.log(chalk.yellow("- S3 bucket and all website files"));
   console.log(chalk.yellow("- Database and all stored data"));
@@ -124,8 +148,8 @@ export async function DestroyCommand() {
         } else {
           return true;
         }
-      }
-    }
+      },
+    },
   ]);
 
   if (confirmDestruction.trim() !== "DESTROY") {
@@ -137,12 +161,7 @@ export async function DestroyCommand() {
     await checkAWSConfiguration();
 
     const stacksToDestroy = await listAllStacks();
-    await destroyStacks(
-      cliPath,
-      awsAccountId.trim(),
-      awsRegion,
-      stacksToDestroy
-    );
+    await destroyStacks(awsAccountId.trim(), awsRegion, stacksToDestroy);
 
     console.log(chalk.green("\nPendulum successfully destroyed from AWS!"));
     console.log(chalk.blue("Destruction details:"));
@@ -156,7 +175,6 @@ export async function DestroyCommand() {
     console.log("- DocumentDB cluster and data");
     console.log("- VPC and networking components");
     console.log("- Security groups and IAM roles");
-    console.log("- ECR repositories and container images");
     console.log("");
     console.log(chalk.gray("AWS billing should stop for these resources."));
   } catch (error) {
@@ -170,4 +188,4 @@ export async function DestroyCommand() {
     console.log("- S3 buckets with versioning may need manual cleanup");
     process.exit(1);
   }
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = "1";
 import { Command } from "commander";
 import { InitCommand } from "./commands/init";
 import { DevCommand } from "./commands/dev";


### PR DESCRIPTION
Improvements in behavior of `deploy` and `destroy` commands:
- relies solely on user in put or hardcoded values for deployment
- will work with NPM packages instead of referencing directories directly
- improved formatting of output information